### PR TITLE
Update CommandAPI dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'xyz.xenondevs.invui:inventory-access-r17:1.31'
     implementation 'xyz.xenondevs.invui:inventory-access-r18:1.31'
     implementation 'xyz.xenondevs.invui:inventory-access-r19:1.31'
-    implementation 'dev.jorel:commandapi-bukkit-shade:9.5.0-SNAPSHOT'
+    implementation 'dev.jorel:commandapi-bukkit-shade:9.5.0'
     implementation 'com.github.Anon8281:UniversalScheduler:0.1.6'
 
     compileOnly 'io.papermc.paper:paper-api:1.20.1-R0.1-SNAPSHOT'
@@ -76,7 +76,7 @@ shadowJar {
         include dependency('xyz.xenondevs.invui:inventory-access-r17')
         include dependency('xyz.xenondevs.invui:inventory-access-r18')
         include dependency('xyz.xenondevs.invui:inventory-access-r19')
-        include dependency('dev.jorel:commandapi-bukkit-shade')
+        include dependency('dev.jorel:commandapi-bukkit-shade:9.5.0')
         include dependency('com.github.Anon8281:UniversalScheduler:0.1.6')
     }
 


### PR DESCRIPTION
Changed the CommandAPI dependencies' because we weren't able to resolve it and set it to the release version of 9.5.0 (According to this documentation https://commandapi.jorel.dev/9.5.0/setup_shading.html )