### PR TITLE
Improve compatibility with other plugins by not cancelling chat events

### DIFF
--- a/src/main/java/dev/unnm3d/redischat/chat/listeners/ChatListenerWithPriority.java
+++ b/src/main/java/dev/unnm3d/redischat/chat/listeners/ChatListenerWithPriority.java
@@ -59,7 +59,7 @@ public enum ChatListenerWithPriority {
 
         public void listenChat(AsyncPlayerChatEvent event) {
             if (event.isCancelled()) return;
-            event.setCancelled(true);
+            event.getRecipients().clear(); // Prevent chat from being shown to players
             plugin.getChannelManager().outgoingMessage(event.getPlayer(), event.getMessage());
         }
     }


### PR DESCRIPTION
Previously, RedisChat cancelled AsyncPlayerChatEvent directly, which prevents plugins like DiscordSRV from seeing the message.

This PR replaces `event.setCancelled(true)` with `event.getRecipients().clear()`, which suppresses local message broadcasting but still allows observers like DiscordSRV to receive the event.

This improves cross-plugin compatibility, especially for DiscordSRV integration, while preserving RedisChat's control over chat routing.

Tested working with DiscordSRV. No known regressions.