### PR TITLE
added a flag to determine whether discord messages should be sent to …

### DIFF
--- a/src/main/java/dev/unnm3d/redischat/discord/SpicordHook.java
+++ b/src/main/java/dev/unnm3d/redischat/discord/SpicordHook.java
@@ -84,6 +84,7 @@ public class SpicordHook extends SimpleAddon implements IDiscordHook {
     @Override
     public void onMessageReceived(DiscordBot bot, MessageReceivedEvent event) {
         if (event.getAuthor().isBot()) return;
+        if (!plugin.config.spicord.discordReceiver()) return;
         plugin.config.spicord.spicordChannelLink().entrySet().stream()
                 .filter(channelLink -> channelLink.getValue().equals(event.getGuildChannel().getId()))
                 .forEach(channelLink -> {

--- a/src/main/java/dev/unnm3d/redischat/settings/Config.java
+++ b/src/main/java/dev/unnm3d/redischat/settings/Config.java
@@ -312,7 +312,7 @@ public final class Config implements ConfigValidator {
             "Every channel of RedisChat is linked with a channel on Discord",
             "The first element is a RedisChat channel, the second one is a Discord channel id",
             "You can find the Discord channel id by right clicking on the channel and clicking on 'Copy ID'"})
-    public SpicordSettings spicord = new SpicordSettings(true, "<blue>[Discord]</blue> %role% %username% » {message}", "**%channel%** %sender% » {message}", Map.of("public", "1127207189547847740"));
+    public SpicordSettings spicord = new SpicordSettings(true, true, "<blue>[Discord]</blue> %role% %username% » {message}", "**%channel%** %sender% » {message}", Map.of("public", "1127207189547847740"));
 
     @Override
     public boolean validateConfig() {
@@ -431,6 +431,7 @@ public final class Config implements ConfigValidator {
 
     public record SpicordSettings(
             boolean enabled,
+            boolean discordReceiver,
             String chatFormat,
             String discordFormat,
             Map<String, String> spicordChannelLink


### PR DESCRIPTION
The plugin needs to have spicord enabled on every server in order to post to a discord channel. This causes incoming messages from discord >> chat to be multiplied by the number of servers it is running on.

This change adds a flag called discordReceiver under the spicord section of the config. If true then the messages will be published to chat. If false they will be discorded. For each network only a single server should have discordReceiver set to true to prevent duplicate chat messages.